### PR TITLE
Get gc2053 sensor working with 4.4 (wyze v3)

### DIFF
--- a/4.4/isp/t31/include/tx-isp-common.h
+++ b/4.4/isp/t31/include/tx-isp-common.h
@@ -29,6 +29,9 @@
 #define TX_ISP_DS1_CAHNNEL_MAX_WIDTH		1920
 #define TX_ISP_DS1_CAHNNEL_MAX_HEIGHT		1080
 
+/* Color settings */
+#define V4L2_MBUS_FMT_SBGGR10_1X10 0x3007
+#define V4L2_MBUS_FMT_SRGGB10_1X10 0x300f
 
 /*****************************************************
  			sensor attributes

--- a/4.4/sensor-src/t31/gc2053.c
+++ b/4.4/sensor-src/t31/gc2053.c
@@ -16,6 +16,13 @@
 #include <tx-isp-common.h>
 #include <sensor-common.h>
 #include <sensor-info.h>
+#include <txx-funcs.h>
+
+// ugly hack, but oh well
+#undef ISP_PRINT
+#define ISP_PRINT(level, format, ...)			\
+	pr_err(format, ##__VA_ARGS__)
+
 
 #define SENSOR_NAME "gc2053"
 #define SENSOR_BUS_TYPE TX_SENSOR_CONTROL_INTERFACE_I2C
@@ -92,36 +99,36 @@ struct again_lut {
 };
 
 struct again_lut sensor_again_lut[] = {
-	// inx, 0xb4 0xb3 0xb8 0xb9 gain
-	{0x00, 0x00, 0x00, 0x01, 0x00, 0},      //   1.000000
-	{0x01, 0x00, 0x10, 0x01, 0x0c, 13726},  //   1.156250
-	{0x02, 0x00, 0x20, 0x01, 0x1b, 31177},  //   1.390625
-	{0x03, 0x00, 0x30, 0x01, 0x2c, 44067},  //   1.593750
-	{0x04, 0x00, 0x40, 0x01, 0x3f, 64793},  //   1.984375
-	{0x05, 0x00, 0x50, 0x02, 0x16, 78621},  //   2.296875
-	{0x06, 0x00, 0x60, 0x02, 0x35, 96180},  //   2.765625
-	{0x07, 0x00, 0x70, 0x03, 0x16, 109138}, //   3.171875
-	{0x08, 0x00, 0x80, 0x04, 0x02, 132537}, //   4.062500
-	{0x09, 0x00, 0x90, 0x04, 0x31, 146067}, //   4.687500
-	{0x0a, 0x00, 0xa0, 0x05, 0x32, 163567}, //   5.640625
-	{0x0b, 0x00, 0xb0, 0x06, 0x35, 176747}, //   6.484375
-	{0x0c, 0x00, 0xc0, 0x08, 0x04, 195118}, //   7.875000
-	{0x0d, 0x00, 0x5a, 0x09, 0x19, 208560}, //   9.078125
-	{0x0e, 0x00, 0x83, 0x0b, 0x0f, 229103}, //  11.281250
-	{0x0f, 0x00, 0x93, 0x0d, 0x12, 242511}, //  13.000000
-	{0x10, 0x00, 0x84, 0x10, 0x00, 262419}, //  16.046875
-	{0x11, 0x00, 0x94, 0x12, 0x3a, 275710}, //  18.468750
-	{0x12, 0x01, 0x2c, 0x1a, 0x02, 292252}, //  22.000000
-	{0x13, 0x01, 0x3c, 0x1b, 0x20, 305571}, //  25.328125
-	{0x14, 0x00, 0x8c, 0x20, 0x0f, 324962}, //  31.093750
-	{0x15, 0x00, 0x9c, 0x26, 0x07, 338280}, //  35.796875
-	{0x16, 0x02, 0x64, 0x36, 0x21, 358923}, //  44.531250
-	{0x17, 0x02, 0x74, 0x37, 0x3a, 372267}, //  51.281250
-	{0x18, 0x00, 0xc6, 0x3d, 0x02, 392101}, //  63.250000
-	{0x19, 0x00, 0xdc, 0x3f, 0x3f, 415415}, //  80.937500
-	{0x1a, 0x02, 0x85, 0x3f, 0x3f, 421082}, //  85.937500
-	{0x1b, 0x02, 0x95, 0x3f, 0x3f, 440360}, // 105.375000
-	{0x1c, 0x00, 0xce, 0x3f, 0x3f, 444864}, // 110.515625
+        // inx, 0xb4 0xb3 0xb8 0xb9 gain
+        {0x00, 0x00, 0x00, 0x01, 0x00, 0},      //   1.000000
+        {0x01, 0x00, 0x10, 0x01, 0x0c, 13726},  //   1.156250
+        {0x02, 0x00, 0x20, 0x01, 0x1b, 31177},  //   1.390625
+        {0x03, 0x00, 0x30, 0x01, 0x2c, 44067},  //   1.593750
+        {0x04, 0x00, 0x40, 0x01, 0x3f, 64793},  //   1.984375
+        {0x05, 0x00, 0x50, 0x02, 0x16, 78621},  //   2.296875
+        {0x06, 0x00, 0x60, 0x02, 0x35, 96180},  //   2.765625
+        {0x07, 0x00, 0x70, 0x03, 0x16, 109138}, //   3.171875
+        {0x08, 0x00, 0x80, 0x04, 0x02, 132537}, //   4.062500
+        {0x09, 0x00, 0x90, 0x04, 0x31, 146067}, //   4.687500
+        {0x0a, 0x00, 0xa0, 0x05, 0x32, 163567}, //   5.640625
+        {0x0b, 0x00, 0xb0, 0x06, 0x35, 176747}, //   6.484375
+        {0x0c, 0x00, 0xc0, 0x08, 0x04, 195118}, //   7.875000
+        {0x0d, 0x00, 0x5a, 0x09, 0x19, 208560}, //   9.078125
+        {0x0e, 0x00, 0x83, 0x0b, 0x0f, 229103}, //  11.281250
+        {0x0f, 0x00, 0x93, 0x0d, 0x12, 242511}, //  13.000000
+        {0x10, 0x00, 0x84, 0x10, 0x00, 262419}, //  16.046875
+        {0x11, 0x00, 0x94, 0x12, 0x3a, 275710}, //  18.468750
+        {0x12, 0x01, 0x2c, 0x1a, 0x02, 292252}, //  22.000000
+        {0x13, 0x01, 0x3c, 0x1b, 0x20, 305571}, //  25.328125
+        {0x14, 0x00, 0x8c, 0x20, 0x0f, 324962}, //  31.093750
+        {0x15, 0x00, 0x9c, 0x26, 0x07, 338280}, //  35.796875
+        {0x16, 0x02, 0x64, 0x36, 0x21, 358923}, //  44.531250
+        {0x17, 0x02, 0x74, 0x37, 0x3a, 372267}, //  51.281250
+        {0x18, 0x00, 0xc6, 0x3d, 0x02, 392101}, //  63.250000
+        {0x19, 0x00, 0xdc, 0x3f, 0x3f, 415415}, //  80.937500
+        {0x1a, 0x02, 0x85, 0x3f, 0x3f, 421082}, //  85.937500
+        {0x1b, 0x02, 0x95, 0x3f, 0x3f, 440360}, // 105.375000
+        {0x1c, 0x00, 0xce, 0x3f, 0x3f, 444864}, // 110.515625
 };
 
 struct tx_isp_sensor_attribute sensor_attr;
@@ -1243,7 +1250,7 @@ int sensor_read(struct tx_isp_subdev *sd, unsigned char reg, unsigned char *valu
 		}
 	};
 	int ret;
-	ret = private_i2c_transfer(client->adapter, msg, 2);
+	ret = i2c_transfer(client->adapter, msg, 2);
 	if (ret > 0)
 		ret = 0;
 
@@ -1260,20 +1267,20 @@ int sensor_write(struct tx_isp_subdev *sd, unsigned char reg, unsigned char valu
 		.buf = buf,
 	};
 	int ret;
-	ret = private_i2c_transfer(client->adapter, &msg, 1);
+	ret = i2c_transfer(client->adapter, &msg, 1);
 	if (ret > 0)
 		ret = 0;
 
 	return ret;
 }
 
-#if 0
+
 static int sensor_read_array(struct tx_isp_subdev *sd, struct regval_list *vals) {
 	int ret;
 	unsigned char val;
 	while (vals->reg_num != SENSOR_REG_END) {
 		if (vals->reg_num == SENSOR_REG_DELAY) {
-			private_msleep(vals->value);
+			msleep(vals->value);
 		} else {
 			ret = sensor_read(sd, vals->reg_num, &val);
 			if (ret < 0)
@@ -1283,17 +1290,18 @@ static int sensor_read_array(struct tx_isp_subdev *sd, struct regval_list *vals)
 	}
 	return 0;
 }
-#endif
+
 
 static int sensor_write_array(struct tx_isp_subdev *sd, struct regval_list *vals) {
 	int ret;
 	while (vals->reg_num != SENSOR_REG_END) {
 		if (vals->reg_num == SENSOR_REG_DELAY) {
-			private_msleep(vals->value);
+			msleep(vals->value);
 		} else {
 			ret = sensor_write(sd, vals->reg_num, vals->value);
-			if (ret < 0)
+			if (ret < 0) {
 				return ret;
+			}
 		}
 		vals++;
 	}
@@ -1392,6 +1400,10 @@ static int sensor_set_analog_gain(struct tx_isp_subdev *sd, int value) {
 }
 #endif
 
+static int sensor_set_logic(struct tx_isp_subdev *sd, int value) {
+	return 0;
+}
+
 static int sensor_set_digital_gain(struct tx_isp_subdev *sd, int value) {
 	return 0;
 }
@@ -1404,8 +1416,9 @@ static int sensor_init(struct tx_isp_subdev *sd, int enable) {
 	struct tx_isp_sensor *sensor = sd_to_sensor_device(sd);
 	int ret = 0;
 
-	if (!enable)
+	if (!enable) {
 		return ISP_SUCCESS;
+	}
 
 	sensor->video.mbus.width = wsize->width;
 	sensor->video.mbus.height = wsize->height;
@@ -1542,29 +1555,28 @@ static int sensor_g_chip_ident(struct tx_isp_subdev *sd, struct tx_isp_chip_iden
 	struct i2c_client *client = tx_isp_get_subdevdata(sd);
 	unsigned int ident = 0;
 	int ret = ISP_SUCCESS;
-
 	if (reset_gpio != -1) {
-		ret = private_gpio_request(reset_gpio, "sensor_reset");
+		ret = gpio_request(reset_gpio, "sensor_reset");
 		if (!ret) {
-			private_gpio_direction_output(reset_gpio, 1);
-			private_msleep(20);
-			private_gpio_direction_output(reset_gpio, 0);
-			private_msleep(20);
-			private_gpio_direction_output(reset_gpio, 1);
-			private_msleep(10);
+			gpio_direction_output(reset_gpio, 1);
+			msleep(20);
+			gpio_direction_output(reset_gpio, 0);
+			msleep(20);
+			gpio_direction_output(reset_gpio, 1);
+			msleep(10);
 		} else {
 			ISP_ERROR("gpio requrest fail %d\n", reset_gpio);
 		}
 	}
 	if (pwdn_gpio != -1) {
-		ret = private_gpio_request(pwdn_gpio, "sensor_pwdn");
+		ret = gpio_request(pwdn_gpio, "sensor_pwdn");
 		if (!ret) {
-			private_gpio_direction_output(pwdn_gpio, 1);
-			private_msleep(10);
-			private_gpio_direction_output(pwdn_gpio, 0);
-			private_msleep(10);
-			private_gpio_direction_output(pwdn_gpio, 1);
-			private_msleep(10);
+			gpio_direction_output(pwdn_gpio, 1);
+			msleep(10);
+			gpio_direction_output(pwdn_gpio, 0);
+			msleep(10);
+			gpio_direction_output(pwdn_gpio, 1);
+			msleep(10);
 		} else {
 			ISP_ERROR("gpio requrest fail %d\n", pwdn_gpio);
 		}
@@ -1648,6 +1660,7 @@ static int sensor_sensor_ops_ioctl(struct tx_isp_subdev *sd, unsigned int cmd, v
 		default:
 			break;
 	}
+
 	return ret;
 }
 
@@ -1655,31 +1668,34 @@ static int sensor_g_register(struct tx_isp_subdev *sd, struct tx_isp_dbg_registe
 	unsigned char val = 0;
 	int len = 0;
 	int ret = 0;
+
 	len = strlen(sd->chip.name);
 	if (len && strncmp(sd->chip.name, reg->name, len)) {
 		return -EINVAL;
 	}
-
-	if (!private_capable(CAP_SYS_ADMIN))
+	if (!capable(CAP_SYS_ADMIN)) {
 		return -EPERM;
-
+	}
 	ret = sensor_read(sd, reg->reg & 0xffff, &val);
 	reg->val = val;
 	reg->size = 2;
+
 	return ret;
 }
 
 static int sensor_s_register(struct tx_isp_subdev *sd, const struct tx_isp_dbg_register *reg) {
 	int len = 0;
+
 	len = strlen(sd->chip.name);
 	if (len && strncmp(sd->chip.name, reg->name, len)) {
 		return -EINVAL;
 	}
-
-	if (!private_capable(CAP_SYS_ADMIN))
+	if (!capable(CAP_SYS_ADMIN)) {
 		return -EPERM;
+	}
 
 	sensor_write(sd, reg->reg & 0xffff, reg->val & 0xff);
+
 	return 0;
 }
 
@@ -1731,14 +1747,17 @@ static int sensor_probe(struct i2c_client *client, const struct i2c_device_id *i
 	}
 
 	memset(sensor, 0, sizeof(*sensor));
-	sensor->mclk = clk_get(NULL, "cgu_cim");
+
+	sensor->mclk = clk_get(NULL, "div_cim");
 	if (IS_ERR(sensor->mclk)) {
-		ISP_ERROR("Cannot get sensor input clock cgu_cim\n");
+		ISP_ERROR("Cannot get sensor input clock div_cim\n");
 		goto err_get_mclk;
 	}
 
-	private_clk_set_rate(sensor->mclk, 24000000);
-	private_clk_enable(sensor->mclk);
+	clk_set_rate(sensor->mclk, 24000000);
+    clk_prepare_enable(sensor->mclk);
+
+	private_jzgpio_set_func(GPIO_PORT_A, GPIO_FUNC_1, 0x8000);
 	sensor_attr.dbus_type = data_interface;
 	if ((data_interface == TX_SENSOR_DATA_INTERFACE_DVP) && (sensor_max_fps == TX_SENSOR_MAX_FPS_30)) {
 		ret = set_sensor_gpio_function(sensor_gpio_func);
@@ -1854,32 +1873,40 @@ static int sensor_probe(struct i2c_client *client, const struct i2c_device_id *i
 	tx_isp_subdev_init(&sensor_platform_device, sd, &sensor_ops);
 	tx_isp_set_subdevdata(sd, client);
 	tx_isp_set_subdev_hostdata(sd, sensor);
-	private_i2c_set_clientdata(client, sd);
+	i2c_set_clientdata(client, sd);
+
 	pr_debug("probe ok ------->%s\n", SENSOR_NAME);
+
 	return 0;
 
 err_set_sensor_data_interface:
 err_set_sensor_gpio:
-	private_clk_disable(sensor->mclk);
-	private_clk_put(sensor->mclk);
+    clk_disable(sensor->mclk);
+    clk_put(sensor->mclk);
 err_get_mclk:
+	clk_disable(sensor->mclk);
+	clk_put(sensor->mclk);
 	kfree(sensor);
+
 	return -1;
 }
 
 static int sensor_remove(struct i2c_client *client) {
-	struct tx_isp_subdev *sd = private_i2c_get_clientdata(client);
+	struct tx_isp_subdev *sd = i2c_get_clientdata(client);
 	struct tx_isp_sensor *sensor = tx_isp_get_subdev_hostdata(sd);
 
-	if (reset_gpio != -1)
-		private_gpio_free(reset_gpio);
-	if (pwdn_gpio != -1)
-		private_gpio_free(pwdn_gpio);
+	if (reset_gpio != -1) {
+		gpio_free(reset_gpio);
+	}
+	if (pwdn_gpio != -1) {
+		gpio_free(pwdn_gpio);
+	}
 
-	private_clk_disable(sensor->mclk);
-	private_clk_put(sensor->mclk);
+	clk_disable(sensor->mclk);
+	clk_put(sensor->mclk);
 	tx_isp_subdev_deinit(sd);
 	kfree(sensor);
+
 	return 0;
 }
 
@@ -1887,8 +1914,8 @@ static const struct i2c_device_id sensor_id[] = {
 	{SENSOR_NAME, 0},
 	{}
 };
-
-MODULE_DEVICE_TABLE(i2c, sensor_id);
+MODULE_DEVICE_TABLE(i2c, sensor_id
+);
 
 static struct i2c_driver sensor_driver = {
 	.driver = {
@@ -1901,19 +1928,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
-	int ret = 0;
-        sensor_common_init(&sensor_info);
-
-	ret = private_driver_get_interface();
-	if (ret) {
-		ISP_ERROR("Failed to init %s driver.\n", SENSOR_NAME);
-		return -1;
-	}
-	return private_i2c_add_driver(&sensor_driver);
+	sensor_common_init(&sensor_info);
+	return i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
-	private_i2c_del_driver(&sensor_driver);
+	i2c_del_driver(&sensor_driver);
 	sensor_common_exit();
 }
 

--- a/4.4/sensor-src/t31/sc2336.c
+++ b/4.4/sensor-src/t31/sc2336.c
@@ -45,7 +45,6 @@
 #define SENSOR_OUTPUT_MIN_FPS 5
 #define SENSOR_VERSION "H20210805a"
 
-#define V4L2_MBUS_FMT_SBGGR10_1X10 0x3007
 
 static int reset_gpio = -1;
 module_param(reset_gpio, int, S_IRUGO);


### PR DESCRIPTION

* Get gc2053 sensor working with 4.4
* set the config value from 3.10 headers for RGB, define constant in header for t31; leverage it in the sc2336 driver as well.