### PR TITLE
Corrected issue with struct sensor_mipi_2 naming

### DIFF
--- a/3.10/sensor-src/t31/sc3336.c
+++ b/3.10/sensor-src/t31/sc3336.c
@@ -383,7 +383,7 @@ struct tx_isp_mipi_bus sensor_mipi_1m={
     .mipi_sc.sensor_mode = TX_SENSOR_DEFAULT_MODE,
 };
 
-struct tx_isp_mipi_bus sensor_mipi_ ={
+struct tx_isp_mipi_bus sensor_mipi_2 ={
 	.mode = SENSOR_MIPI_OTHER_MODE,
 	.clk = 510,
 	.lans = 2,


### PR DESCRIPTION
Driver for sensor sc3336 wouldn't compile because struct sensor_mipi_2 used in sensor_probe is missing. Upon inspection, I found the struct is declared but "2" is missing at the end of the name.