### PR TITLE
To fix the below error with compiling with 4.4.94 kernel.

### DIFF
--- a/4.4/audio/t31/oss3/inner_codecs/codec.h
+++ b/4.4/audio/t31/oss3/inner_codecs/codec.h
@@ -10,7 +10,7 @@
 #include <linux/gpio.h>
 //#include <mach/jzsnd.h>
 #include <linux/bitops.h>
-#include <codec-common.h>
+#include "../include/codec-common.h"
 
 #define BASE_ADDR_CODEC			0x10021000
 


### PR DESCRIPTION
To fix the below error with compiling with 4.4.94 kernel.
4.4/audio/t31/oss3/inner_codecs/codec.h:13:10: fatal error: codec-common.h: No such file or directory
   13 | #include <codec-common.h>
      |          ^~~~~~~~~~~~~~~~

Even its Makefile has the following line, codec-common.h is not referred because it is not used to compile.

EXTRA_CFLAGS += -I$(PWD)/include

Therefore, changing the C code is a only solution.