### PR TITLE
export symbol isp_printf in t21 tx-isp-debug.c

### DIFF
--- a/3.10/isp/t21/tx-isp-debug.c
+++ b/3.10/isp/t21/tx-isp-debug.c
@@ -30,6 +30,7 @@ int isp_printf(unsigned int level, unsigned char *fmt, ...)
 	}
 	return r;
 }
+EXPORT_SYMBOL(isp_printf);
 
 int get_isp_clk(void)
 {


### PR DESCRIPTION
Fixes unknown symbol isp_printf error