### PR TITLE
Implement motor driver for 4.4

### DIFF
--- a/4.4/misc/motor/Kbuild
+++ b/4.4/misc/motor/Kbuild
@@ -1,8 +1,8 @@
-# Match the factory module name
 MODULE_NAME := motor
+
 OUT := $(MODULE_NAME)
 
-DIR=$(KERNEL_VERSION)/misc/motor
+DIR := $(KERNEL_VERSION)/misc/motor
 
 SRCS := $(DIR)/motor.c
 

--- a/4.4/misc/tcu_alloc/Kbuild
+++ b/4.4/misc/tcu_alloc/Kbuild
@@ -1,0 +1,9 @@
+DIR := $(KERNEL_VERSION)/misc/tcu_alloc
+
+TCU_ALLOC_MODULE := tcu_alloc
+OBJS := $(DIR)/tcu_alloc.o
+
+obj-m += $(TCU_ALLOC_MODULE).o
+
+$(TCU_ALLOC_MODULE)-objs := $(OBJS)
+

--- a/4.4/misc/tcu_alloc/tcu_alloc.c
+++ b/4.4/misc/tcu_alloc/tcu_alloc.c
@@ -1,0 +1,85 @@
+#include <linux/module.h>
+#include <linux/spinlock.h>
+#include <linux/errno.h>
+#include <linux/printk.h>
+#include "tcu_alloc.h"
+
+static DEFINE_SPINLOCK(tcu_lock);
+static unsigned int tcu_max_channels = 8;
+static unsigned long tcu_claim_bitmap; /* up to 32 channels */
+static char tcu_owner_name[TCU_ALLOC_MAX_CHANNELS][32];
+
+int tcu_alloc_set_max_channels(unsigned int n)
+{
+	unsigned long flags;
+	if (n == 0 || n > TCU_ALLOC_MAX_CHANNELS)
+		return -EINVAL;
+	spin_lock_irqsave(&tcu_lock, flags);
+	if (n > tcu_max_channels)
+		tcu_max_channels = n; /* only grow; never shrink to avoid dropping claims */
+	spin_unlock_irqrestore(&tcu_lock, flags);
+	return 0;
+}
+EXPORT_SYMBOL_GPL(tcu_alloc_set_max_channels);
+
+int tcu_alloc_claim(unsigned int ch, const char *owner)
+{
+	unsigned long flags;
+	if (ch >= tcu_max_channels)
+		return -EINVAL;
+	spin_lock_irqsave(&tcu_lock, flags);
+	if (tcu_claim_bitmap & (1UL << ch)) {
+		const char *cur = tcu_owner_name[ch][0] ? tcu_owner_name[ch] : "unknown";
+		spin_unlock_irqrestore(&tcu_lock, flags);
+		pr_err("TCU: channel %u already claimed by %s, cannot assign to %s\n", ch, cur, owner ? owner : "unknown");
+		return -EBUSY;
+	}
+	tcu_claim_bitmap |= (1UL << ch);
+	if (owner)
+		strlcpy(tcu_owner_name[ch], owner, sizeof(tcu_owner_name[ch]));
+	else
+		tcu_owner_name[ch][0] = '\0';
+	spin_unlock_irqrestore(&tcu_lock, flags);
+	pr_info("TCU: channel %u claimed by %s\n", ch, owner ? owner : "unknown");
+	return 0;
+}
+EXPORT_SYMBOL_GPL(tcu_alloc_claim);
+
+void tcu_alloc_release(unsigned int ch, const char *owner)
+{
+	unsigned long flags;
+	if (ch >= tcu_max_channels)
+		return;
+	spin_lock_irqsave(&tcu_lock, flags);
+	tcu_claim_bitmap &= ~(1UL << ch);
+	tcu_owner_name[ch][0] = '\0';
+	spin_unlock_irqrestore(&tcu_lock, flags);
+	pr_info("TCU: channel %u released (by %s)\n", ch, owner ? owner : "unknown");
+}
+EXPORT_SYMBOL_GPL(tcu_alloc_release);
+
+bool tcu_alloc_is_claimed(unsigned int ch)
+{
+	bool ret;
+	unsigned long flags;
+	if (ch >= tcu_max_channels)
+		return false;
+	spin_lock_irqsave(&tcu_lock, flags);
+	ret = tcu_claim_bitmap & (1UL << ch);
+	spin_unlock_irqrestore(&tcu_lock, flags);
+	return ret;
+}
+EXPORT_SYMBOL_GPL(tcu_alloc_is_claimed);
+
+const char *tcu_alloc_owner(unsigned int ch)
+{
+	if (ch >= tcu_max_channels)
+		return NULL;
+	return tcu_owner_name[ch][0] ? tcu_owner_name[ch] : NULL;
+}
+EXPORT_SYMBOL_GPL(tcu_alloc_owner);
+
+MODULE_DESCRIPTION("Ingenic TCU channel ownership registry");
+MODULE_AUTHOR("Augment Agent");
+MODULE_LICENSE("GPL v2");
+

--- a/4.4/misc/tcu_alloc/tcu_alloc.h
+++ b/4.4/misc/tcu_alloc/tcu_alloc.h
@@ -1,0 +1,19 @@
+#ifndef __TCU_ALLOC_H__
+#define __TCU_ALLOC_H__
+
+#include <linux/types.h>
+
+/* Simple central registry for Ingenic TCU channel ownership.
+ * First claimant wins; subsequent claimants get -EBUSY.
+ */
+
+#define TCU_ALLOC_MAX_CHANNELS 16
+
+int tcu_alloc_set_max_channels(unsigned int n);
+int tcu_alloc_claim(unsigned int ch, const char *owner);
+void tcu_alloc_release(unsigned int ch, const char *owner);
+bool tcu_alloc_is_claimed(unsigned int ch);
+const char *tcu_alloc_owner(unsigned int ch);
+
+#endif /* __TCU_ALLOC_H__ */
+

--- a/Kbuild
+++ b/Kbuild
@@ -25,11 +25,9 @@ ifeq ($(KERNEL_VERSION),3.10)
 endif
 
 
-# Build TCU allocator (central ownership registry) for 3.10
-ifeq ($(KERNEL_VERSION),3.10)
-    $(info Building TCU allocator for Kernel $(KERNEL_VERSION))
-    include $(src)/$(KERNEL_VERSION)/misc/tcu_alloc/Kbuild
-endif
+# Build TCU allocator (central ownership registry) for both 3.10 and 4.4
+$(info Building TCU allocator for Kernel $(KERNEL_VERSION))
+include $(src)/$(KERNEL_VERSION)/misc/tcu_alloc/Kbuild
 
 ifeq ($(KERNEL_VERSION),3.10)
     $(info Building PWM for Kernel $(KERNEL_VERSION))


### PR DESCRIPTION
Here's my current progress, and I think it's usable right now.

This is based on existing code from both 4.4 and 3.10, and further enhanced to allow smoother diagonal movement.

Current differences to 3.10:

- no `invert_direction_polarity`, `motor_switch_gpio`, `hmotor2vmotor`
- has optional GPIO endstops
- smoother diagonal movement
- use current step count to determine power on state(which coil to power) so the torque is applied correctly