### PR TITLE
private_vmalloc/private_kmalloc: log allocation failures

### DIFF
--- a/3.10.14/isp/t21/txx-funcs.c
+++ b/3.10.14/isp/t21/txx-funcs.c
@@ -121,9 +121,12 @@ int  private_kthread_stop(struct task_struct *k)
 	return kthread_stop(k);
 }
 
-void *  private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
-	return kmalloc(s, gfp);
+	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
+	return addr;
 }
 
 void  private_kfree(void *p)

--- a/3.10.14/isp/t23/tx-isp-debug.c
+++ b/3.10.14/isp/t23/tx-isp-debug.c
@@ -124,6 +124,8 @@ int get_mipi_switch_gpio(void)
 void *private_vmalloc(unsigned long size)
 {
     void *addr = vmalloc(size);
+    if (!addr)
+        pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
     return addr;
 }
 

--- a/3.10.14/isp/t31/tx-isp-debug.c
+++ b/3.10.14/isp/t31/tx-isp-debug.c
@@ -65,6 +65,8 @@ int get_isp_clk(void)
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 

--- a/3.10.14/isp/t41/tx-isp-funcs.c
+++ b/3.10.14/isp/t41/tx-isp-funcs.c
@@ -717,6 +717,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -725,9 +727,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 

--- a/4.4.94/fb/a1/private-funcs.c
+++ b/4.4.94/fb/a1/private-funcs.c
@@ -455,6 +455,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -463,9 +465,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 

--- a/4.4.94/ipu/a1/private-funcs.c
+++ b/4.4.94/ipu/a1/private-funcs.c
@@ -367,6 +367,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -375,9 +377,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 

--- a/4.4.94/isp/t31/tx-isp-debug.c
+++ b/4.4.94/isp/t31/tx-isp-debug.c
@@ -563,6 +563,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -571,9 +573,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 

--- a/4.4.94/isp/t40/tx-isp-funcs.c
+++ b/4.4.94/isp/t40/tx-isp-funcs.c
@@ -515,6 +515,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -523,9 +525,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 

--- a/4.4.94/isp/t41/tx-isp-funcs.c
+++ b/4.4.94/isp/t41/tx-isp-funcs.c
@@ -752,6 +752,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -760,9 +762,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 

--- a/4.4.94/video/a1/vde/vde_funcs.c
+++ b/4.4.94/video/a1/vde/vde_funcs.c
@@ -605,6 +605,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -613,9 +615,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 

--- a/4.4.94/video/a1/vdec/vdec-funcs.c
+++ b/4.4.94/video/a1/vdec/vdec-funcs.c
@@ -427,6 +427,8 @@ struct proc_dir_entry *private_proc_create_data(const char *name, umode_t mode,
 void *private_vmalloc(unsigned long size)
 {
 	void *addr = vmalloc(size);
+	if (!addr)
+		pr_err("%s: vmalloc(%lu) failed\n", __func__, size);
 	return addr;
 }
 
@@ -435,9 +437,11 @@ void private_vfree(const void *addr)
 	vfree(addr);
 }
 
-void * private_kmalloc(size_t s, gfp_t gfp)
+void *private_kmalloc(size_t s, gfp_t gfp)
 {
 	void *addr = kmalloc(s, gfp);
+	if (!addr)
+		pr_err("%s: kmalloc(%zu) failed\n", __func__, s);
 	return addr;
 }
 


### PR DESCRIPTION
These thin wrappers around vmalloc() and kmalloc() silently return NULL when the underlying allocator fails.  Add a pr_err() so allocation failures are visible in dmesg for debugging, rather than propagating silently to an eventual (and confusing) NULL dereference or module crash.

While here, fix the inconsistent whitespace (void<space>*name -> void *name) in private_kmalloc across all definition sites.

Applies to every kernel tree (3.10, 4.4) and SoC (t21, t23, t31, t40, t41) as well as the fb, ipu, and video subsystems that carry their own copies of these wrappers.

Ref: https://github.com/themactep/ingenic-sdk/pull/40