### PR TITLE
sensors: t41: wire sc5336 and sc4336p to /proc/jz/sensor

### DIFF
--- a/4.4.94/sensor-src/t41/sc4336p.c
+++ b/4.4.94/sensor-src/t41/sc4336p.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,              /* linear */
+	.mclk = 1,              /* MCLK1 */
+	.video_interface = 0,   /* MIPI CSI0 */
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -854,6 +871,24 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+
+	/* Update sensor_info for /proc/jz/sensor/ with the values the ISP
+	 * framework resolved at probe time. The proc entries read from
+	 * sensor_info at access time, so refreshing the struct here is
+	 * enough — sensor_common_init was already called in init_sensor. */
+	if (info->rst_gpio >= 0)
+		sensor_info.rst_gpio = info->rst_gpio;
+	if (info->pwdn_gpio >= 0)
+		sensor_info.pwdn_gpio = info->pwdn_gpio;
+	/* Cast to int — enum types are unsigned, so -1 wraps to UINT_MAX. */
+	if ((int)info->default_boot >= 0)
+		sensor_info.boot = info->default_boot;
+	if ((int)info->mclk >= 0)
+		sensor_info.mclk = (int)info->mclk;
+	if ((int)info->video_interface >= 0)
+		sensor_info.video_interface = (int)info->video_interface;
+	sensor_info.i2c_adapter = client->adapter->nr;
+
 	return 0;
 }
 
@@ -1090,10 +1125,15 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	/* Create /proc/jz/sensor/ entries with static defaults now; dynamic
+	 * fields (boot/mclk/gpio/i2c_adapter) are refreshed in
+	 * sensor_attr_check once the ISP framework probes the sensor. */
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc5336.c
+++ b/4.4.94/sensor-src/t41/sc5336.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,              /* linear */
+	.mclk = 1,              /* MCLK1 */
+	.video_interface = 0,   /* MIPI CSI0 */
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -887,6 +904,24 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+
+	/* Update sensor_info for /proc/jz/sensor/ with the values the ISP
+	 * framework resolved at probe time. The proc entries read from
+	 * sensor_info at access time, so refreshing the struct here is
+	 * enough — sensor_common_init was already called in init_sensor. */
+	if (info->rst_gpio >= 0)
+		sensor_info.rst_gpio = info->rst_gpio;
+	if (info->pwdn_gpio >= 0)
+		sensor_info.pwdn_gpio = info->pwdn_gpio;
+	/* Cast to int — enum types are unsigned, so -1 wraps to UINT_MAX. */
+	if ((int)info->default_boot >= 0)
+		sensor_info.boot = info->default_boot;
+	if ((int)info->mclk >= 0)
+		sensor_info.mclk = (int)info->mclk;
+	if ((int)info->video_interface >= 0)
+		sensor_info.video_interface = (int)info->video_interface;
+	sensor_info.i2c_adapter = client->adapter->nr;
+
 	return 0;
 
 }
@@ -1124,10 +1159,15 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	/* Create /proc/jz/sensor/ entries with static defaults now; dynamic
+	 * fields (boot/mclk/gpio/i2c_adapter) are refreshed in
+	 * sensor_attr_check once the ISP framework probes the sensor. */
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 


### PR DESCRIPTION
## What

`sc5336.c` and `sc4336p.c` (T41, 4.4.94) `#include <sensor-info.h>` but never call `sensor_common_init()`, so loading either module creates no `/proc/jz/sensor/` tree.

## Why it matters

Userspace that auto-detects the sensor from `/proc/jz/sensor/name` (e.g. raptor's `rvd`) can't bring up the pipeline without it — it fails with *"sensor name not in config and not in /proc/jz/sensor/name"*. `gc4023.c` is currently the only wired T41/4.4 driver; every other sensor silently lacks the proc tree.

## Change

Follows the existing `gc4023.c` pattern exactly, for both sensors:
- add a static `sensor_info` populated with name/chip-id/resolution/fps/i2c/gpio/mclk defaults;
- `sensor_common_init(&sensor_info)` in `init_sensor()` (creates the proc tree at insmod with static defaults, independent of I2C detection) and `sensor_common_exit()` in `exit_sensor()`;
- refresh the dynamic fields (rst/pwdn gpio, boot, mclk, video_interface, i2c_adapter) from the ISP-resolved values at the end of `sensor_attr_check()`.

No functional change to the streaming path; purely adds the proc registration.

## Testing

Verified on a T41 camera (Hugolog E5P, SC4336P): `/proc/jz/sensor/name` now reports `sc4336p`, and `rvd` initialises the pipeline and streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)