### PR TITLE
sensors: wire remaining 4.4 drivers to /proc/jz/sensor

### DIFF
--- a/4.4.94/sensor-src/common/sensor-info.c
+++ b/4.4.94/sensor-src/common/sensor-info.c
@@ -180,6 +180,25 @@ void sensor_common_init(struct sensor_info *info) {
 	}
 }
 
+void sensor_common_update(struct sensor_info *info, int rst_gpio, int pwdn_gpio,
+			  int boot, int mclk, int video_interface,
+			  int i2c_adapter) {
+	if (!info)
+		return;
+
+	if (rst_gpio >= 0)
+		info->rst_gpio = rst_gpio;
+	if (pwdn_gpio >= 0)
+		info->pwdn_gpio = pwdn_gpio;
+	if (boot >= 0)
+		info->boot = boot;
+	if (mclk >= 0)
+		info->mclk = mclk;
+	if (video_interface >= 0)
+		info->video_interface = video_interface;
+	info->i2c_adapter = i2c_adapter;
+}
+
 void sensor_common_exit(void) {
 	/* Note: Each sensor driver should call this with its own info pointer */
 	/* For now, we rely on the proc entries being cleaned up when the module unloads */

--- a/4.4.94/sensor-src/include/sensor-info.h
+++ b/4.4.94/sensor-src/include/sensor-info.h
@@ -20,6 +20,9 @@ struct sensor_info {
 };
 
 void sensor_common_init(struct sensor_info *info);
+void sensor_common_update(struct sensor_info *info, int rst_gpio, int pwdn_gpio,
+			  int boot, int mclk, int video_interface,
+			  int i2c_adapter);
 void sensor_common_exit(void);
 
 #endif // SENSOR_INFO_H

--- a/4.4.94/sensor-src/t40/mis4001.c
+++ b/4.4.94/sensor-src/t40/mis4001.c
@@ -49,6 +49,23 @@ static int shvflip = 0;
 module_param(shvflip, int, S_IRUGO);
 MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = SENSOR_CHIP_ID,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
     uint16_t reg_num;
     unsigned char value;
@@ -908,6 +925,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	reset_gpio = info->rst_gpio;
 	pwdn_gpio = info->pwdn_gpio;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1159,11 +1179,13 @@ static struct i2c_driver sensor_driver = {
 
 static __init int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t40/mis4001s1.c
+++ b/4.4.94/sensor-src/t40/mis4001s1.c
@@ -49,6 +49,23 @@ static int shvflip = 0;
 module_param(shvflip, int, S_IRUGO);
 MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = SENSOR_CHIP_ID,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
     uint16_t reg_num;
     unsigned char value;
@@ -908,6 +925,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	reset_gpio = info->rst_gpio;
 	pwdn_gpio = info->pwdn_gpio;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1159,11 +1179,13 @@ static struct i2c_driver sensor_driver = {
 
 static __init int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t40/sc3338.c
+++ b/4.4.94/sensor-src/t40/sc3338.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -847,6 +864,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1083,10 +1103,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/cv2001.c
+++ b/4.4.94/sensor-src/t41/cv2001.c
@@ -35,6 +35,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = 5,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -539,6 +556,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -772,10 +792,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/cv2003.c
+++ b/4.4.94/sensor-src/t41/cv2003.c
@@ -44,6 +44,23 @@ static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -877,6 +894,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1121,10 +1141,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/cv3001.c
+++ b/4.4.94/sensor-src/t41/cv3001.c
@@ -35,6 +35,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = 5,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -526,6 +543,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -759,10 +779,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/cv4001.c
+++ b/4.4.94/sensor-src/t41/cv4001.c
@@ -35,6 +35,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = 5,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -550,6 +567,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -783,10 +803,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/cv5001.c
+++ b/4.4.94/sensor-src/t41/cv5001.c
@@ -35,6 +35,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = 5,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -543,6 +560,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -776,10 +796,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc2063.c
+++ b/4.4.94/sensor-src/t41/gc2063.c
@@ -44,6 +44,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -1100,6 +1117,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 err_set_sensor_gpio:
 	return -1;
@@ -1337,10 +1357,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc2083.c
+++ b/4.4.94/sensor-src/t41/gc2083.c
@@ -43,6 +43,23 @@ static int reset_gpio = GPIO_PC(27);
 static int pwdn_gpio = -1;
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned int reg_num;
 	unsigned char value;
@@ -694,6 +711,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 err_get_mclk:
 	return ret;
 }
@@ -955,10 +975,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc2607.c
+++ b/4.4.94/sensor-src/t41/gc2607.c
@@ -43,6 +43,23 @@ static int reset_gpio = GPIO_PC(27);
 static int pwdn_gpio = -1;
 static int shvflip = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned int reg_num;
 	unsigned char value;
@@ -652,6 +669,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 err_get_mclk:
 	return ret;
 }
@@ -887,10 +907,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc3003.c
+++ b/4.4.94/sensor-src/t41/gc3003.c
@@ -50,6 +50,23 @@ static int fsync_mode = 3;
 module_param(fsync_mode, int, S_IRUGO);
 MODULE_PARM_DESC(fsync_mode, "Sensor Indicates the frame synchronization mode");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -774,6 +791,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1055,10 +1075,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc3003a.c
+++ b/4.4.94/sensor-src/t41/gc3003a.c
@@ -47,6 +47,23 @@ static int reset_gpio = -1;
 static int pwdn_gpio = GPIO_PA(4);
 static int shvflip = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = -1,
+	.pwdn_gpio = GPIO_PA(4),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -743,6 +760,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1012,10 +1032,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc3003s1.c
+++ b/4.4.94/sensor-src/t41/gc3003s1.c
@@ -49,6 +49,23 @@ static int fsync_mode = 3;
 module_param(fsync_mode, int, S_IRUGO);
 MODULE_PARM_DESC(fsync_mode, "Sensor Indicates the frame synchronization mode");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -773,6 +790,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1064,10 +1084,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc4023s1.c
+++ b/4.4.94/sensor-src/t41/gc4023s1.c
@@ -55,6 +55,23 @@ struct proc_dir_entry *g_sinfo_proc;
 module_param(shvflip, int, S_IRUGO);
 MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1991,6 +2008,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -2244,6 +2264,7 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	g_sinfo_proc = proc_mkdir(CAMERA_PROC_NAME, 0);
 	if (!g_sinfo_proc) {
 		printk("err: jz_proc_mkdir failed\n");
@@ -2254,6 +2275,7 @@ static __init int init_sensor(void) {
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	proc_remove(g_sinfo_proc);
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41/gc4663.c
+++ b/4.4.94/sensor-src/t41/gc4663.c
@@ -46,6 +46,23 @@
 
 static int wdr_bufsize = 2 * 3000 * 188;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1263,6 +1280,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 		ISP_WARNING("Description Failed to synchronize the attributes of sensor!!!");
 	}
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1577,10 +1597,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc5603s0.c
+++ b/4.4.94/sensor-src/t41/gc5603s0.c
@@ -51,6 +51,23 @@ static int fsync_mode = 3;
 module_param(fsync_mode, int, S_IRUGO);
 MODULE_PARM_DESC(fsync_mode, "Sensor Indicates the frame synchronization mode");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1421,6 +1438,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1777,10 +1797,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc5603s1.c
+++ b/4.4.94/sensor-src/t41/gc5603s1.c
@@ -51,6 +51,23 @@ static int fsync_mode = 3;
 module_param(fsync_mode, int, S_IRUGO);
 MODULE_PARM_DESC(fsync_mode, "Sensor Indicates the frame synchronization mode");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1422,6 +1439,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1743,10 +1763,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc5613.c
+++ b/4.4.94/sensor-src/t41/gc5613.c
@@ -43,6 +43,23 @@ static int reset_gpio = GPIO_PC(27);
 static int pwdn_gpio = -1;
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2816,
+	.height = 1584,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -752,6 +769,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -999,11 +1019,13 @@ static struct i2c_driver sensor_driver = {
 
 static __init int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/gc8613.c
+++ b/4.4.94/sensor-src/t41/gc8613.c
@@ -44,6 +44,23 @@ static int reset_gpio = GPIO_PC(27);
 static int pwdn_gpio = -1;
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1394,6 +1411,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1635,10 +1655,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx327.c
+++ b/4.4.94/sensor-src/t41/imx327.c
@@ -64,6 +64,23 @@ MODULE_PARM_DESC(wdr_bufsize, "Wdr Buf Size");
 
 static int rhs1 = 101;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1006,6 +1023,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1261,10 +1281,12 @@ static struct i2c_driver imx327_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&imx327_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&imx327_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx335.c
+++ b/4.4.94/sensor-src/t41/imx335.c
@@ -49,6 +49,23 @@ static int data_type = TX_SENSOR_DATA_TYPE_LINEAR;
 static int wdr_bufsize = 7080000;
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = SENSOR_CHIP_ID,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2592,
+	.height = 1944,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -931,6 +948,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1196,11 +1216,13 @@ static struct i2c_driver sensor_driver = {
 
 static __init int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
         return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void)
 {
+	sensor_common_exit();
         private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx386.c
+++ b/4.4.94/sensor-src/t41/imx386.c
@@ -49,6 +49,23 @@ MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 static int reset_gpio = GPIO_PC(28);
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 15,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1267,6 +1284,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1502,10 +1522,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx415.c
+++ b/4.4.94/sensor-src/t41/imx415.c
@@ -54,6 +54,23 @@ static int data_type = TX_SENSOR_DATA_TYPE_LINEAR;
 
 static int wdr_bufsize = 7080000;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1391,6 +1408,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1649,10 +1669,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx482.c
+++ b/4.4.94/sensor-src/t41/imx482.c
@@ -46,6 +46,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -869,6 +886,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1098,10 +1118,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx515.c
+++ b/4.4.94/sensor-src/t41/imx515.c
@@ -62,6 +62,23 @@ static int wdr_bufsize = 7080000;
 module_param(wdr_bufsize, int, S_IRUGO);
 MODULE_PARM_DESC(wdr_bufsize, "Wdr Buf Size");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = SENSOR_CHIP_ID,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -960,6 +977,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1206,10 +1226,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx662.c
+++ b/4.4.94/sensor-src/t41/imx662.c
@@ -64,6 +64,23 @@ MODULE_PARM_DESC(wdr_bufsize, "Wdr Buf Size");
 
 static int rhs1 = 101;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1225,6 +1242,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1480,10 +1500,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/imx664.c
+++ b/4.4.94/sensor-src/t41/imx664.c
@@ -53,6 +53,23 @@ static int data_type = TX_SENSOR_DATA_TYPE_LINEAR;
 
 static int wdr_bufsize = 5376000;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = SENSOR_CHIP_ID,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2688,
+	.height = 1520,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1202,6 +1219,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 		sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 		ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 		return 0;
 
 err_get_mclk:
@@ -1462,10 +1482,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/jxf37.c
+++ b/4.4.94/sensor-src/t41/jxf37.c
@@ -82,6 +82,23 @@ static unsigned char reg_2f = 0x44;
 static unsigned char reg_0c = 0x00;
 static unsigned char reg_82 = 0x21;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -1934,6 +1951,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_set_sensor_gpio:
@@ -2259,10 +2279,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/jxf51.c
+++ b/4.4.94/sensor-src/t41/jxf51.c
@@ -43,6 +43,23 @@ static int shvflip = 0;
 module_param(shvflip, int, S_IRUGO);
 MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1536,
+	.height = 1536,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -754,6 +771,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1054,10 +1074,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/jxk06.c
+++ b/4.4.94/sensor-src/t41/jxk06.c
@@ -42,6 +42,23 @@
 
 uint8_t dismode;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -780,6 +797,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1026,6 +1046,7 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	/* ret = private_driver_get_interface(); */
 	/* if (ret) { */
 	/* 	ISP_ERROR("Failed to init %s driver.\n", SENSOR_NAME); */
@@ -1035,6 +1056,7 @@ static __init int init_sensor(void) {
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/jxk08.c
+++ b/4.4.94/sensor-src/t41/jxk08.c
@@ -48,6 +48,23 @@ static int shvflip = 1;
 module_param(shvflip, int, S_IRUGO);
 MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -865,6 +882,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1107,6 +1127,7 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	/* ret = private_driver_get_interface(); */
 	/* if (ret) { */
 	/* 	ISP_ERROR("Failed to init %s driver.\n", SENSOR_NAME); */
@@ -1116,6 +1137,7 @@ static __init int init_sensor(void) {
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/mis2009.c
+++ b/4.4.94/sensor-src/t41/mis2009.c
@@ -47,6 +47,23 @@ static unsigned char sv_state = 0;
 static bool trig_logic = false;
 static unsigned int vic_reset = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -918,6 +935,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1164,10 +1184,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/mis4001.c
+++ b/4.4.94/sensor-src/t41/mis4001.c
@@ -47,6 +47,23 @@ static unsigned char sv_state = 0;
 static bool trig_logic = false;
 static unsigned int vic_reset = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -951,6 +968,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1199,10 +1219,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/mis5011.c
+++ b/4.4.94/sensor-src/t41/mis5011.c
@@ -45,6 +45,23 @@
 static int reset_gpio = GPIO_PC(18);
 static int pwdn_gpio = -1;//GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2960,
+	.height = 1632,
+	.rst_gpio = GPIO_PC(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1880,6 +1897,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -2119,10 +2139,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/os04a10.c
+++ b/4.4.94/sensor-src/t41/os04a10.c
@@ -46,6 +46,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2688,
+	.height = 1520,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -2119,6 +2136,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -2356,10 +2376,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/os04c10.c
+++ b/4.4.94/sensor-src/t41/os04c10.c
@@ -46,6 +46,23 @@ static int pwdn_gpio = -1;
 static int wdr_bufsize = 1400000;
 static unsigned char switch_wdr = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 20,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2688,
+	.height = 1520,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1709,6 +1726,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -2036,10 +2056,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/os08a10.c
+++ b/4.4.94/sensor-src/t41/os08a10.c
@@ -53,6 +53,23 @@ static int wdr_bufsize = 2400000; // cache lines corrponding on VPB1
 module_param(wdr_bufsize, int, S_IRUGO);
 MODULE_PARM_DESC(wdr_bufsize, "Wdr Buf Size");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1200,
+	.height = 800,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1507,6 +1524,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1754,10 +1774,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/ov01a1s.c
+++ b/4.4.94/sensor-src/t41/ov01a1s.c
@@ -40,6 +40,23 @@
 static int reset_gpio = GPIO_PC(28);
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1280,
+	.height = 720,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -728,6 +745,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -961,10 +981,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/ov2736.c
+++ b/4.4.94/sensor-src/t41/ov2736.c
@@ -43,6 +43,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -862,6 +879,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1099,10 +1119,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/ov5675.c
+++ b/4.4.94/sensor-src/t41/ov5675.c
@@ -44,6 +44,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 15,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2592,
+	.height = 1944,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -808,6 +825,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1046,10 +1066,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/ov5675s1.c
+++ b/4.4.94/sensor-src/t41/ov5675s1.c
@@ -42,6 +42,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 15,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2592,
+	.height = 1944,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -805,6 +822,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1044,10 +1064,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/ov7251.c
+++ b/4.4.94/sensor-src/t41/ov7251.c
@@ -44,6 +44,23 @@
 static int reset_gpio = GPIO_PC(27);
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 320,
+	.height = 240,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -934,6 +951,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1170,10 +1190,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/ov9281.c
+++ b/4.4.94/sensor-src/t41/ov9281.c
@@ -49,6 +49,23 @@ static int pwdn_gpio = -1;
 
 struct tx_isp_sensor_attribute sensor_attr;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1280,
+	.height = 800,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -854,6 +871,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	sensor->priv = wsize;
 	//ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1127,10 +1147,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/ov9640.c
+++ b/4.4.94/sensor-src/t41/ov9640.c
@@ -44,6 +44,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1280,
+	.height = 720,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -3051,6 +3068,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
         sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -3295,11 +3315,13 @@ static struct i2c_driver sensor_driver = {
 
 static __init int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/rn6752.c
+++ b/4.4.94/sensor-src/t41/rn6752.c
@@ -47,6 +47,23 @@
 static int reset_gpio = GPIO_PA(18);
 //static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 720,
+	.height = 240,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -843,6 +860,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1180,6 +1200,7 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	/* ret = private_driver_get_interface(); */
 	/* if (ret) { */
 	/* 	ISP_ERROR("Failed to init %s driver.\n", SENSOR_NAME); */
@@ -1189,6 +1210,7 @@ static __init int init_sensor(void) {
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc031gs.c
+++ b/4.4.94/sensor-src/t41/sc031gs.c
@@ -44,6 +44,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 120,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 640,
+	.height = 480,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1070,6 +1087,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1308,10 +1328,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc200ai.c
+++ b/4.4.94/sensor-src/t41/sc200ai.c
@@ -51,6 +51,23 @@ static int shvflip = 1;
 
 static int data_type = TX_SENSOR_DATA_TYPE_WDR_DOL;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PC(18),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1374,6 +1391,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1704,10 +1724,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc2210.c
+++ b/4.4.94/sensor-src/t41/sc2210.c
@@ -50,6 +50,23 @@ static int shvflip = 0;
 module_param(shvflip, int, S_IRUGO);
 MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1242,6 +1259,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1510,10 +1530,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc230ai.c
+++ b/4.4.94/sensor-src/t41/sc230ai.c
@@ -51,6 +51,23 @@ static int shvflip = 1;
 
 static int data_type = TX_SENSOR_DATA_TYPE_WDR_DOL;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PC(18),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1436,6 +1453,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1766,10 +1786,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc2336.c
+++ b/4.4.94/sensor-src/t41/sc2336.c
@@ -57,6 +57,23 @@ MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
 //static unsigned int expo_val = 0x031f0320;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PA(17),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -844,6 +861,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1081,10 +1101,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc233a.c
+++ b/4.4.94/sensor-src/t41/sc233a.c
@@ -49,6 +49,23 @@ static int shvflip = 1;
 static unsigned char switch_wdr = 1;
 static int data_type = TX_SENSOR_DATA_TYPE_WDR_DOL;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1288,6 +1305,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	pwdn_gpio = info->pwdn_gpio;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1613,10 +1633,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc301iot.c
+++ b/4.4.94/sensor-src/t41/sc301iot.c
@@ -51,6 +51,23 @@ static int pwdn_gpio = -1;
 static int wdr_bufsize = 2048 * 400;//cache lines corrponding on VPB1
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2048,
+	.height = 1536,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1426,6 +1443,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->video.shvflip = shvflip;
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1756,10 +1776,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc3332.c
+++ b/4.4.94/sensor-src/t41/sc3332.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 15,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -836,6 +853,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1072,10 +1092,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc3332p.c
+++ b/4.4.94/sensor-src/t41/sc3332p.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 15,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -843,6 +860,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1079,10 +1099,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc3336.c
+++ b/4.4.94/sensor-src/t41/sc3336.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -847,6 +864,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1083,10 +1103,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc3336p.c
+++ b/4.4.94/sensor-src/t41/sc3336p.c
@@ -47,6 +47,23 @@ static int fsync_mode = 3;
 module_param(fsync_mode, int, S_IRUGO);
 MODULE_PARM_DESC(fsync_mode, "Sensor Indicates the frame synchronization mode");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1698,6 +1715,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1970,10 +1990,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc3336ps1.c
+++ b/4.4.94/sensor-src/t41/sc3336ps1.c
@@ -49,6 +49,23 @@ static int fsync_mode = 3;
 module_param(fsync_mode, int, S_IRUGO);
 MODULE_PARM_DESC(fsync_mode, "Sensor Indicates the frame synchronization mode");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1693,6 +1710,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1960,10 +1980,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc3338.c
+++ b/4.4.94/sensor-src/t41/sc3338.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -847,6 +864,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1083,10 +1103,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc401ai.c
+++ b/4.4.94/sensor-src/t41/sc401ai.c
@@ -45,6 +45,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1472,6 +1489,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1710,10 +1730,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc401ais1.c
+++ b/4.4.94/sensor-src/t41/sc401ais1.c
@@ -43,6 +43,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1440,6 +1457,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1654,10 +1674,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc4210.c
+++ b/4.4.94/sensor-src/t41/sc4210.c
@@ -52,6 +52,23 @@ static int shvflip = 0;
 module_param(shvflip, int, S_IRUGO);
 MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1846,6 +1863,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -2114,10 +2134,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc430ai.c
+++ b/4.4.94/sensor-src/t41/sc430ai.c
@@ -50,6 +50,23 @@ static int wdr_bufsize = 1400 * 1000;
 static int shvflip = 0;
 static unsigned char switch_wdr = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2688,
+	.height = 1520,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1429,6 +1446,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	pwdn_gpio = info->pwdn_gpio;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1769,10 +1789,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc4336.c
+++ b/4.4.94/sensor-src/t41/sc4336.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -819,6 +836,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1055,10 +1075,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc450ai.c
+++ b/4.4.94/sensor-src/t41/sc450ai.c
@@ -45,6 +45,23 @@ static int pwdn_gpio = -1;
 
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2592,
+	.height = 1520,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1369,6 +1386,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1613,10 +1633,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc500ai.c
+++ b/4.4.94/sensor-src/t41/sc500ai.c
@@ -51,6 +51,23 @@ static int shvflip = 1;
 
 static int data_type = TX_SENSOR_DATA_TYPE_WDR_DOL;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1506,6 +1523,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1837,10 +1857,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc500ais1.c
+++ b/4.4.94/sensor-src/t41/sc500ais1.c
@@ -51,6 +51,23 @@ static int shvflip = 1;
 
 static int data_type = TX_SENSOR_DATA_TYPE_WDR_DOL;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1509,6 +1526,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1814,10 +1834,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc501ai.c
+++ b/4.4.94/sensor-src/t41/sc501ai.c
@@ -45,6 +45,23 @@ static int pwdn_gpio = -1;
 
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -977,6 +994,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 	ret = tx_isp_call_subdev_notify(sd, TX_ISP_EVENT_SYNC_SENSOR_ATTR, &sensor->video);
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1221,10 +1241,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc5239.c
+++ b/4.4.94/sensor-src/t41/sc5239.c
@@ -45,6 +45,23 @@ static int pwdn_gpio = -1;
 static int wdr_bufsize = 1380 * 4000 * 2;
 static unsigned char switch_wdr = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1920,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1306,6 +1323,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1614,10 +1634,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc531ai.c
+++ b/4.4.94/sensor-src/t41/sc531ai.c
@@ -44,6 +44,24 @@ static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = -1;
 
 static int shvflip = 1;
+
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1192,6 +1210,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1439,10 +1460,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc5338.c
+++ b/4.4.94/sensor-src/t41/sc5338.c
@@ -47,6 +47,23 @@ static int wdr_bufsize = 5760000;//1000*2880*2
 static int data_type = TX_SENSOR_DATA_TYPE_WDR_DOL;
 static unsigned char switch_wdr = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1207,6 +1224,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1533,10 +1553,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc8238.c
+++ b/4.4.94/sensor-src/t41/sc8238.c
@@ -42,6 +42,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 15,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1992,6 +2009,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -2229,10 +2249,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/sc830ai.c
+++ b/4.4.94/sensor-src/t41/sc830ai.c
@@ -56,6 +56,23 @@ static int wdr_bufsize = 3840000;  /*  1000*1920*2 */
 static int shvflip = 1;
 static int data_type = TX_SENSOR_DATA_TYPE_WDR_DOL;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -2097,6 +2114,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -2480,10 +2500,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41/tp9963.c
+++ b/4.4.94/sensor-src/t41/tp9963.c
@@ -42,6 +42,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -686,6 +703,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -893,10 +913,12 @@ static struct i2c_driver sensor_driver = {
 };
 
 static __init int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 static __exit void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }
 

--- a/4.4.94/sensor-src/t41zrt/gc2063.c
+++ b/4.4.94/sensor-src/t41zrt/gc2063.c
@@ -45,6 +45,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -1112,6 +1129,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 err_set_sensor_gpio:
 	return -1;
@@ -1379,9 +1399,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/gc2083.c
+++ b/4.4.94/sensor-src/t41zrt/gc2083.c
@@ -44,6 +44,23 @@ static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = -1;
 static int shvflip = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned int reg_num;
 	unsigned char value;
@@ -705,6 +722,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 err_get_mclk:
 	return ret;
 }
@@ -966,9 +986,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/gc3003.c
+++ b/4.4.94/sensor-src/t41zrt/gc3003.c
@@ -48,6 +48,23 @@ static int reset_gpio = -1;
 static int pwdn_gpio = GPIO_PA(4);
 static int shvflip = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 16) | (SENSOR_CHIP_ID_M << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = -1,
+	.pwdn_gpio = GPIO_PA(4),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -962,6 +979,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1256,9 +1276,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/gc4023.c
+++ b/4.4.94/sensor-src/t41zrt/gc4023.c
@@ -56,6 +56,23 @@ static int shvflip = 1;
 //module_param(shvflip, int, S_IRUGO);
 //MODULE_PARM_DESC(shvflip, "Sensor HV Flip Enable interface");
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1829,6 +1846,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -2095,9 +2115,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/gc4653.c
+++ b/4.4.94/sensor-src/t41zrt/gc4653.c
@@ -41,6 +41,23 @@
 //#define SENSOR_WITHOUT_INIT
 static int wdr_bufsize = 2 * 3000 * 188;//cache lines corrponding on VPB1
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1070,6 +1087,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	//sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1409,9 +1429,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/gc4663.c
+++ b/4.4.94/sensor-src/t41zrt/gc4663.c
@@ -58,6 +58,23 @@
 
 static int wdr_bufsize = 2 * 3000 * 188;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 25,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1173,6 +1190,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 		ISP_WARNING("Description Failed to synchronize the attributes of sensor!!!");
 	}
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1511,9 +1531,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/gc5603.c
+++ b/4.4.94/sensor-src/t41zrt/gc5603.c
@@ -48,6 +48,23 @@ static int pwdn_gpio = -1;
 static int wdr_bufsize = 2 * 4800 * 400;//cache lines corrponding on VPB1
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1020,6 +1037,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1366,9 +1386,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/imx335.c
+++ b/4.4.94/sensor-src/t41zrt/imx335.c
@@ -47,6 +47,23 @@
 static int reset_gpio = GPIO_PC(28);
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -906,6 +923,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 }
 
@@ -1170,9 +1190,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 int exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/imx415.c
+++ b/4.4.94/sensor-src/t41zrt/imx415.c
@@ -47,6 +47,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -828,6 +845,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1090,9 +1110,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&imx415_driver);
 }
 
 int exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&imx415_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/jxf37.c
+++ b/4.4.94/sensor-src/t41zrt/jxf37.c
@@ -62,6 +62,23 @@ static unsigned char reg_2f = 0x44;
 static unsigned char reg_0c = 0x00;
 static unsigned char reg_82 = 0x21;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 1920,
+	.height = 1080,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	unsigned char reg_num;
 	unsigned char value;
@@ -1923,6 +1940,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_set_sensor_gpio:
@@ -2275,10 +2295,12 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	printk("############## initsensor\n");
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc301iot.c
+++ b/4.4.94/sensor-src/t41zrt/sc301iot.c
@@ -49,6 +49,23 @@ static int pwdn_gpio = -1;
 static int wdr_bufsize = 2048 * 400;//cache lines corrponding on VPB1
 static int shvflip = 1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2048,
+	.height = 1536,
+	.rst_gpio = GPIO_PC(27),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1247,6 +1264,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
 	sensor_set_attr(sd, wsize);
 	sensor->video.shvflip = shvflip;
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1613,10 +1633,12 @@ int get_sensor_wdr_mode(void)
 
 int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc3336.c
+++ b/4.4.94/sensor-src/t41zrt/sc3336.c
@@ -45,6 +45,24 @@ static int pwdn_gpio = -1;
 static int data_interface = TX_SENSOR_DATA_INTERFACE_MIPI;
 static int shvflip = 0;
 static int sensor_max_fps = TX_SENSOR_MAX_FPS_30;
+
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2304,
+	.height = 1296,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -930,6 +948,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	reset_gpio = info->rst_gpio;
 	pwdn_gpio = info->pwdn_gpio;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1234,9 +1255,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc401ai.c
+++ b/4.4.94/sensor-src/t41zrt/sc401ai.c
@@ -55,6 +55,23 @@
 static int reset_gpio = GPIO_PC(28);
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 30,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1389,6 +1406,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1663,10 +1683,12 @@ int get_sensor_wdr_mode(void)
 
 int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 int exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc4336p.c
+++ b/4.4.94/sensor-src/t41zrt/sc4336p.c
@@ -44,6 +44,23 @@ static int data_interface = TX_SENSOR_DATA_INTERFACE_MIPI;
 
 static int shvflip = 0;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1440,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
         uint16_t reg_num;
         unsigned char value;
@@ -831,6 +848,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
         sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
         return 0;
 
 err_get_mclk:
@@ -1117,10 +1137,12 @@ int get_sensor_wdr_mode(void)
 
 int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 int exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc500ai.c
+++ b/4.4.94/sensor-src/t41zrt/sc500ai.c
@@ -45,6 +45,23 @@ static int shvflip = 0;
 
 static bool dpc_flag = true;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = GPIO_PC(28),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1123,6 +1140,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
 	pwdn_gpio = info->pwdn_gpio;
         sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1441,10 +1461,12 @@ int get_sensor_wdr_mode(void)
 
 int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc5239.c
+++ b/4.4.94/sensor-src/t41zrt/sc5239.c
@@ -43,6 +43,23 @@ static int pwdn_gpio = GPIO_PA(19);
 
 static unsigned int expo_val = 0x031f0320;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2560,
+	.height = 1920,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1159,6 +1176,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1433,9 +1453,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 int exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc531ai.c
+++ b/4.4.94/sensor-src/t41zrt/sc531ai.c
@@ -42,6 +42,24 @@ static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = -1;
 
 static int shvflip = 1;
+
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = SENSOR_OUTPUT_MAX_FPS,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1001,6 +1019,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
     sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 err_get_mclk:
@@ -1292,10 +1313,12 @@ int get_sensor_wdr_mode(void)
 
 int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 void exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc5336.c
+++ b/4.4.94/sensor-src/t41zrt/sc5336.c
@@ -42,6 +42,23 @@
 static int reset_gpio = GPIO_PA(18);
 static int pwdn_gpio = GPIO_PA(19);
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 20,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 2880,
+	.height = 1620,
+	.rst_gpio = GPIO_PA(18),
+	.pwdn_gpio = GPIO_PA(19),
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -893,6 +910,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1154,9 +1174,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 int exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc8238.c
+++ b/4.4.94/sensor-src/t41zrt/sc8238.c
@@ -45,6 +45,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 15,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -1693,6 +1710,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd) {
 	sensor->priv = wsize;
 	sensor->video.max_fps = wsize->fps;
 	sensor->video.min_fps = SENSOR_OUTPUT_MIN_FPS << 16 | 1;
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1956,9 +1976,11 @@ int get_sensor_wdr_mode(void) {
 }
 
 int init_sensor(void) {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 int exit_sensor(void) {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }

--- a/4.4.94/sensor-src/t41zrt/sc830ai.c
+++ b/4.4.94/sensor-src/t41zrt/sc830ai.c
@@ -42,6 +42,23 @@
 static int reset_gpio = -1;
 static int pwdn_gpio = -1;
 
+static struct sensor_info sensor_info = {
+	.name = SENSOR_NAME,
+	.chip_id = (SENSOR_CHIP_ID_H << 8) | SENSOR_CHIP_ID_L,
+	.version = SENSOR_VERSION,
+	.min_fps = SENSOR_OUTPUT_MIN_FPS,
+	.max_fps = 20,
+	.chip_i2c_addr = SENSOR_I2C_ADDRESS,
+	.width = 3840,
+	.height = 2160,
+	.rst_gpio = -1,
+	.pwdn_gpio = -1,
+	.boot = 0,
+	.mclk = 1,
+	.video_interface = 0,
+	.i2c_adapter = 0,
+};
+
 struct regval_list {
 	uint16_t reg_num;
 	unsigned char value;
@@ -932,6 +949,9 @@ static int sensor_attr_check(struct tx_isp_subdev *sd)
 	sensor_set_attr(sd, wsize);
 	sensor->priv = wsize;
 
+	sensor_common_update(&sensor_info, info->rst_gpio, info->pwdn_gpio,
+			     (int)info->default_boot, (int)info->mclk,
+			     (int)info->video_interface, client->adapter->nr);
 	return 0;
 
 }
@@ -1206,10 +1226,12 @@ int get_sensor_wdr_mode(void)
 
 int init_sensor(void)
 {
+	sensor_common_init(&sensor_info);
 	return private_i2c_add_driver(&sensor_driver);
 }
 
 int exit_sensor(void)
 {
+	sensor_common_exit();
 	private_i2c_del_driver(&sensor_driver);
 }


### PR DESCRIPTION
## Summary
- add a shared sensor_common_update() helper for probe-time GPIO/MCLK/interface/I2C refresh
- wire the remaining 4.4.94 sensor-info.h users to define sensor_info and call sensor_common_init()/sensor_common_exit()
- covers 3 T40 drivers, 71 T41 drivers, and 20 T41ZRT drivers; T31 was already fully wired

## Validation
- git diff --check
- audited 4.4.94 sensor-src: T31/T40/T41/T41ZRT sensor-info.h users all now have struct sensor_info plus init wiring
- built t41/sc4336 with the normal root Kbuild against an existing T41 4.4.94 output
- built t41zrt/sc4336p with a sensor-only Kbuild against T41 4.4.94 headers
- attempted t40/sc3338; full T40 root build stops before sensors on an existing -mnan archive mismatch, and sensor-only build reaches sc3338.c but fails on existing T40 header/API mismatches unrelated to this change
